### PR TITLE
fix: check if null pointer on placement with onRewardedVideoAdRewarded callback

### DIFF
--- a/android/src/main/java/co/squaretwo/ironsource/RNIronSourceRewardedVideoModule.java
+++ b/android/src/main/java/co/squaretwo/ironsource/RNIronSourceRewardedVideoModule.java
@@ -65,6 +65,9 @@ public class RNIronSourceRewardedVideoModule extends ReactContextBaseJavaModule 
                 }
                 @Override
                 public void onRewardedVideoAdRewarded(Placement placement) {
+                    if (placement == null) {
+                        return;
+                    }
                     String rewardName = placement.getRewardName();
                     int rewardAmount = placement.getRewardAmount();
                     Log.d(TAG, "onRewardedVideoAdRewarded() called! " + rewardName + " " + rewardAmount);


### PR DESCRIPTION
initializeRewardedVideo 할때 IronSource.setRewardedVideoListener를 등록하는데 이때 간혹 onRewardedVideoAdRewarded 콜백함수가 불려져 null 인 placement 를 넘겨주면서 에러 발생함에 따른 방어코드 추가

https://app.bugsnag.com/radishfiction/radish/errors/5fe179aa3f2fcb001747d4b0?filters[event.since][0][type]=eq&filters[event.since][0][value]=30d&filters[app.release_stage][0][value]=production&filters[app.release_stage][0][type]=eq